### PR TITLE
Fix rel attribute in SocialPill component

### DIFF
--- a/src/components/SocialPill.astro
+++ b/src/components/SocialPill.astro
@@ -6,6 +6,6 @@
          transition"
     href={Astro.props.href} 
     target="_blank" 
-    rel="nooponed noreferrer">
+    rel="noopener noreferrer">
     <slot></slot>
 </a>


### PR DESCRIPTION
## Summary
- fix typo `rel="nooponed noreferrer"` in `SocialPill.astro`
- ensure file ends with a newline

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc78c56788323a97720c843644c82