### PR TITLE
Fix email SocialPill link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,12 +38,12 @@ import Experience from '../components/Experience.astro';
 						Github
 					</SocialPill>
 				</li>
-				<li>
-					<SocialPill href="https://github.com/GuilleFerres">
-						<MailIcon class="size-6"></MailIcon>
-						guillermoferressanchez@gmail.com
-					</SocialPill>
-				</li>
+                                <li>
+                                        <SocialPill href="mailto:guillermoferressanchez@gmail.com">
+                                                <MailIcon class="size-6"></MailIcon>
+                                                guillermoferressanchez@gmail.com
+                                        </SocialPill>
+                                </li>
 			</ul>
 		</SectionContainer>
 		<SectionContainer>


### PR DESCRIPTION
## Summary
- update email SocialPill to mailto link

## Testing
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc8fec4f48323ab16516fee1757a5