### PR TITLE
Update ExperienceItem link handling

### DIFF
--- a/src/components/ExperienceItem.astro
+++ b/src/components/ExperienceItem.astro
@@ -25,9 +25,9 @@ const { title, description, link, date, latest } = Astro.props
 </h3>
 <time class="block mb-2 text-sm font-normal leading-none text-gray-400 dark:text-gray-500">{date}</time>
 <p class="mb-4 text-base font-normal text-gray-500 dark:text-gray-400">{description}</p>
-{link && 
+{link &&
     (
-        <a href="#" class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:outline-none focus:ring-gray-200 focus:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 dark:focus:ring-gray-700">
+        <a href={link} class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:outline-none focus:ring-gray-200 focus:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 dark:focus:ring-gray-700">
             <svg class="w-3.5 h-3.5 me-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"></svg>
         </a>
     )


### PR DESCRIPTION
## Summary
- use `href={link}` in `ExperienceItem`
- keep link button hidden when no link provided

## Testing
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcae8a7e4832387774fee3f8eeb0e