### PR TITLE
Add basic Vitest setup with SocialPill test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest"
   },
   "dependencies": {
     "@astrojs/check": "^0.4.1",
@@ -16,5 +17,8 @@
     "astro": "^4.3.2",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
+  },
+  "devDependencies": {
+    "vitest": "^1.5.0"
   }
 }

--- a/src/components/__tests__/SocialPill.test.ts
+++ b/src/components/__tests__/SocialPill.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/astro';
+import SocialPill from '../SocialPill.astro';
+
+describe('SocialPill', () => {
+  it('includes rel="noopener noreferrer" when target="_blank"', async () => {
+    const { getByRole } = await render(SocialPill, { props: { href: '/foo' } });
+    const link = getByRole('link');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- add Vitest and test script
- configure Vitest for jsdom environment
- create SocialPill.test verifying rel attribute

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcbc4c1e08323a044ca05318823b7