### PR TITLE
Add blog section and simple backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ npm create astro@latest -- --template basics
 
 This is a personal portfolio built with Astro.
 
+## Blog
+
+La sección de **Blog** se encuentra en `/src/pages/blog`. Puedes iniciar un
+servidor sencillo para gestionar los artículos ejecutando:
+
+```sh
+npm run server
+```
+
+Los artículos de ejemplo se almacenan en `data/posts.json`.
+
 ![just-the-basics](https://github.com/withastro/astro/assets/2244813/a0a5533c-a856-4198-8470-2d67b1d7c554)
 
 ## 🚀 Project Structure

--- a/data/posts.json
+++ b/data/posts.json
@@ -1,0 +1,14 @@
+[
+  {
+    "slug": "primer-post",
+    "title": "Primer post",
+    "date": "2024-01-01",
+    "content": "Contenido del primer post"
+  },
+  {
+    "slug": "segundo-post",
+    "title": "Segundo post",
+    "date": "2024-05-02",
+    "content": "Contenido del segundo post"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "vitest"
+    "test": "vitest",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "@astrojs/check": "^0.4.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,62 @@
+import { createServer } from 'http';
+import { readFileSync, writeFileSync } from 'fs';
+import { parse } from 'url';
+import { resolve } from 'path';
+
+const postsPath = resolve(process.cwd(), 'data', 'posts.json');
+
+function loadPosts() {
+  try {
+    return JSON.parse(readFileSync(postsPath, 'utf-8'));
+  } catch {
+    return [];
+  }
+}
+
+function savePosts(posts) {
+  writeFileSync(postsPath, JSON.stringify(posts, null, 2));
+}
+
+const server = createServer((req, res) => {
+  const url = parse(req.url, true);
+  if (url.pathname === '/posts' && req.method === 'GET') {
+    const posts = loadPosts();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify(posts));
+  }
+
+  if (url.pathname && url.pathname.startsWith('/posts/') && req.method === 'GET') {
+    const slug = url.pathname.split('/').pop();
+    const posts = loadPosts();
+    const post = posts.find(p => p.slug === slug);
+    if (post) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(post));
+    } else {
+      res.writeHead(404);
+      return res.end('Not Found');
+    }
+  }
+
+  if (url.pathname === '/posts' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      const post = JSON.parse(body);
+      const posts = loadPosts();
+      posts.push(post);
+      savePosts(posts);
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(post));
+    });
+    return;
+  }
+
+  res.writeHead(404);
+  res.end('Not Found');
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/pages/__tests__/blog.test.ts
+++ b/src/pages/__tests__/blog.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/astro';
+import BlogIndex from '../blog/index.astro';
+
+import posts from '../../../data/posts.json';
+
+describe('BlogIndex', () => {
+  it('muestra un enlace al primer post', async () => {
+    const { getByText } = await render(BlogIndex, {});
+    const link = getByText(posts[0].title);
+    expect(link.getAttribute('href')).toBe(`/blog/${posts[0].slug}/`);
+  });
+});

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,15 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import posts from '../../../data/posts.json';
+const { slug } = Astro.params;
+const post = posts.find(p => p.slug === slug);
+if (!post) throw new Error(`Post ${slug} not found`);
+---
+
+<Layout title={post.title} description={post.title}>
+  <article class="prose mx-auto">
+    <h1 class="text-3xl font-bold mb-4">{post.title}</h1>
+    <p class="text-sm text-gray-500 mb-8">{post.date}</p>
+    <p>{post.content}</p>
+  </article>
+</Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import posts from '../../../data/posts.json';
+---
+
+<Layout title="Blog" description="Artículos recientes">
+  <h1 class="text-3xl font-bold mb-8">Blog</h1>
+  <ul class="space-y-4">
+    {posts.map(post => (
+      <li>
+        <a href={`/blog/${post.slug}/`} class="text-blue-600 underline">
+          {post.title}
+        </a>
+        <span class="text-sm text-gray-500 ml-2">{post.date}</span>
+      </li>
+    ))}
+  </ul>
+</Layout>


### PR DESCRIPTION
## Summary
- add blog pages to list and show posts
- store posts in `data/posts.json`
- implement a lightweight Node backend to serve posts
- document the blog section and server
- add a basic test for the blog index

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd486f9ec83238a456ec8def5cdfa