### PR TITLE
Move tests outside src

### DIFF
--- a/tests/components/SocialPill.test.ts
+++ b/tests/components/SocialPill.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/astro';
-import SocialPill from '../SocialPill.astro';
+import SocialPill from '../../src/components/SocialPill.astro';
 
 describe('SocialPill', () => {
   it('includes rel="noopener noreferrer" when target="_blank"', async () => {

--- a/tests/pages/blog.test.ts
+++ b/tests/pages/blog.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/astro';
-import BlogIndex from '../blog/index.astro';
+import BlogIndex from '../../src/pages/blog/index.astro';
 
-import posts from '../../../data/posts.json';
+import posts from '../../data/posts.json';
 
 describe('BlogIndex', () => {
   it('muestra un enlace al primer post', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'jsdom'
+    environment: 'jsdom',
+    include: ['tests/**/*.test.ts']
   }
 });


### PR DESCRIPTION
## Summary
- move astro tests out of `src` so Vite dev server no longer loads them
- update import paths and vitest configuration

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run dev` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c382c4f988323bc15f780455c2c6f